### PR TITLE
Adds install target

### DIFF
--- a/template/src/CMakeLists.txt
+++ b/template/src/CMakeLists.txt
@@ -3,3 +3,5 @@ add_subdirectory(PROJECT_NAME)
 # Example executable that uses libPROJECT_NAME:
 add_executable(main main.cpp)
 target_link_libraries(main PROJECT_NAME)
+
+install(TARGETS main DESTINATION bin)

--- a/template/src/PROJECT_NAME/CMakeLists.txt
+++ b/template/src/PROJECT_NAME/CMakeLists.txt
@@ -3,3 +3,6 @@ set(CMAKE_CXX_FLAGS "-O2 -std=c++14 -Wall -Wextra")
 add_library(PROJECT_NAME
     PROJECT_NAME.cpp
 )
+
+install(TARGETS PROJECT_NAME DESTINATION lib)
+install(FILES "${PROJECT_SOURCE_DIR}/include/PROJECT_NAME/PROJECT_NAME.hpp" DESTINATION include)


### PR DESCRIPTION
```
cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.
cmake --build . --target install
```

Results in

```
├── bin
│   └── main
├── include
│   └── PROJECT_NAME.hpp
├── install_manifest.txt
├── lib
│   └── libPROJECT_NAME.a
```

Partially resolves https://github.com/mapbox/cpp-bootstrap/issues/6 --- not sure how to handle public project headers in a clean way.
